### PR TITLE
Direct sampling fix for V3 dongles (Q-branch-needed)

### DIFF
--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -922,7 +922,7 @@ int main(int argc, char **argv)
 #endif
 
 	if (direct_sampling) {
-		verbose_direct_sampling(dev, 1);
+		verbose_direct_sampling(dev, 2);
 	}
 
 	if (offset_tuning) {


### PR DESCRIPTION
RTL-SDR V3 dongles use Q-branch for direct sampling mode. 
But rtl-power.c is misused I-branch for this in verbose_direct_sampling(..) function - option 1 instead of needed 2.
So was changed to using the proper Q-branch.